### PR TITLE
[WIP] Bump to Node 18

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16.x
+          - 18.x
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This PR will switch tests to use Node 18.

This is currently blocked by https://github.com/actions/runner-images/discussions/5429