### PR TITLE
Fix incorrect release versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/github-actions-core",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/github-actions-core",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "description": "A library of functions shared between GitHub Actions.",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
I forgot to update the package.json's version before releasing v0.4.0, to correct this I will figured it would be best to just ship a patch release with this fixed, since I've already applied a tag to the main branch.