### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -4,6 +4,9 @@ name: "Code Quality: TypeScript"
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   nodejs:
     name: Node.js


### PR DESCRIPTION
To fix the problem, explicitly declare a permissions block that restricts the GITHUB_TOKEN to the minimum needed privileges. This workflow only checks out the repository and runs npm scripts locally, so it only needs read access to repository contents.

The best minimal fix without changing functionality is to add a top-level permissions section (so it applies to all jobs) right after the on: block. We’ll set contents: read, which is sufficient for actions/checkout and does not grant write access. No other scopes (issues, pull-requests, packages, etc.) are required based on the shown steps.

Concretely, in .github/workflows/typescript.yml, insert:

permissions:
  contents: read
between the on: block (lines 4–6) and the jobs: block (line 7). No new imports or external dependencies are required.

Suggested fixes powered by Copilot Autofix. Review carefully before merging.