### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,9 @@
 ---
 name: "Code Quality: Super-Linter"
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/github-actions-core/security/code-scanning/1](https://github.com/hashicorp/github-actions-core/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here (without changing functionality): define workflow-level permissions with `contents: read`, which is sufficient for `actions/checkout` and running Super-Linter in this configuration.

Change file: **`.github/workflows/superlinter.yml`**  
Change region: near the top-level keys (`name`, `on`, `jobs`) by inserting:

```yml
permissions:
  contents: read
```

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
