### PR TITLE
Rename 'x32' case to 'ia32' in setup-binary.ts

### DIFF
--- a/setup-binary.ts
+++ b/setup-binary.ts
@@ -121,7 +121,7 @@ function getArch(): string {
       return "arm";
     case "arm64":
       return "arm64";
-    case "x32":
+    case "ia32":
       return "386";
     case "x64":
       return "amd64";


### PR DESCRIPTION
`os.arch` from node's `os` module has a return type of `string` with the following return values `'arm', 'arm64', 'ia32', 'loong64', 'mips', 'mipsel', 'ppc', 'ppc64', 'riscv64', 's390', 's390x', and 'x64'`. `ia32` refers to 32 bit x86 machines hence updating the incorrect reference of `x32` to `ia32`